### PR TITLE
Add MCP wire-protocol conformance IT for the Streamable HTTP endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- MCP wire-protocol conformance testing -->
+        <dependency>
+            <groupId>io.github.senor14</groupId>
+            <artifactId>mcp-java-testkit</artifactId>
+            <version>0.3.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <dependencyManagement>

--- a/src/test/java/com/arvindand/mcp/maven/McpProtocolConformanceIT.java
+++ b/src/test/java/com/arvindand/mcp/maven/McpProtocolConformanceIT.java
@@ -1,0 +1,35 @@
+package com.arvindand.mcp.maven;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import io.github.senor14.mcptestkit.McpAssertions;
+import io.github.senor14.mcptestkit.McpServerTest;
+import io.github.senor14.mcptestkit.McpTestClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Wire-protocol conformance tests for the MCP endpoint: boots the server with the Streamable HTTP
+ * transport on a random port and verifies what an MCP client actually observes on the wire — the
+ * initialize handshake, the declared capabilities, and the published tool list.
+ *
+ * <p>Complements {@link MavenMcpServerIT}, which exercises the underlying services directly rather
+ * than the MCP protocol surface.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles({"test", "http"})
+@McpServerTest(url = "spring:/mcp")
+class McpProtocolConformanceIT {
+
+  @Test
+  void mcpEndpointConformsToProtocol(McpTestClient client) {
+    McpAssertions.assertThat(client)
+        .initializesSuccessfully()
+        .declaresToolsCapability()
+        .hasTools()
+        .toolNamesAreUnique()
+        .toolsHaveDescriptions()
+        .toolSchemasAreValid();
+  }
+}


### PR DESCRIPTION
Adds one integration test that boots the server with the `http` profile on a random port and verifies the MCP surface an actual client observes on the wire:

- the `initialize` handshake completes and the `tools` capability is declared
- the published tool list has unique names, descriptions on every tool, and structurally valid `inputSchema`s

This complements `MavenMcpServerIT`, which exercises the services directly ? a schema regression or a transport/config change that breaks the protocol surface wouldn't be caught there, but fails this test.

**Full disclosure:** the test uses [mcp-java-testkit](https://github.com/senor14/mcp-java-testkit) (Apache-2.0, test-scoped, no transitive baggage beyond Jackson), which I maintain. If you'd rather not take an external test dependency, no hard feelings ? happy to close this, or to inline a dependency-free version of the same checks instead.

Verified locally on JDK 25 with `./mvnw verify -Dit.test=McpProtocolConformanceIT`.
